### PR TITLE
Add script to sync Renovate ignore annotations from manifests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,11 @@ repos:
     rev: v1.52.2
     hooks:
       - id: ggshield
+  - repo: local
+    hooks:
+      - id: renovate-ignore-sync
+        name: Sync '# renovate: ignore' annotations into renovate.json
+        entry: python3 scripts/update-renovate-ignores.py
+        language: system
+        files: \.(ya?ml|json)$
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Renovate is set to automatically and silently upgrade every software package EXC
 
 When upgrades for the above packages are found, Renovate will create a pull request that has to be manually approved (or denied). Once approved, ArgoCD manages the actual upgrade as with any other software.
 
+If an automatic update breaks an app, the image can be pinned to a known-good version and excluded from further upgrades by adding a `# renovate: ignore` comment to the version line in the manifest. A pre-commit hook syncs these annotations into [renovate.json](/renovate.json). See [this document](/docs/RENOVATE-IGNORE.md) for details.
+
 ## Backups
 Since the repo is built using GitOps principles and config is stored in Github, backups aren't required for the bulk of the deployments. This does not cover persistent volumes. For persistent volumes running on NFS, I use [VolSync](/manifests/system/volsync) to backup PVCs to S3 storage. [Longhorn](/manifests/system/longhorn) PVCs uses its own internal backup mechanism to backup to the NAS, which is then in turn backed up to alternate storage.
 

--- a/docs/RENOVATE-IGNORE.md
+++ b/docs/RENOVATE-IGNORE.md
@@ -1,0 +1,64 @@
+# Excluding an app from Renovate auto-upgrades
+
+Sometimes an automatic image update breaks an app and the fix is to pin the image back to a known-good version. Renovate's built-in managers (`kubernetes`, `helm-values`, `kustomize`) cannot read comments or Kubernetes annotations, so on its own Renovate would immediately try to upgrade the pinned image again. Instead of hand-editing `renovate.json` every time, this repo uses a `# renovate: ignore` annotation directly in the manifest.
+
+## How to use it
+
+Pin the image to the working version and append `# renovate: ignore` to the version line:
+
+**Baseline Helm chart `values.yaml` (helm-values manager):**
+```yaml
+image:
+  repository: 11notes/radarr
+  tag: 6.2.0 # renovate: ignore
+  registry: ghcr.io
+```
+
+**Plain deployment/cronjob manifest (kubernetes manager):**
+```yaml
+image: ghcr.io/foo/bar:v1.2.3 # renovate: ignore
+```
+
+**Kustomize image override (kustomize manager):**
+```yaml
+images:
+  - name: ghcr.io/foo/bar
+    newTag: v1.2.3 # renovate: ignore
+```
+
+**Explicit form** (anywhere in any YAML file, for cases where the image name can't be inferred from the surrounding lines, e.g. custom regex managers):
+```yaml
+# renovate: ignore=ghcr.io/foo/bar
+```
+
+Then commit. The [pre-commit](/docs/COMMIT-PRECHECK.md) hook runs [scripts/update-renovate-ignores.py](/scripts/update-renovate-ignores.py), which regenerates a managed rule at the end of `packageRules` in [renovate.json](/renovate.json):
+
+```json
+{
+  "description": "Managed by scripts/update-renovate-ignores.py - do not edit. ...",
+  "matchPackageNames": [
+    "11notes/radarr",
+    "ghcr.io/11notes/radarr"
+  ],
+  "enabled": false
+}
+```
+
+If the hook modified `renovate.json`, pre-commit stops the commit; re-stage the file (`git add renovate.json`) and commit again. The script can also be run manually at any time:
+
+```sh
+python3 scripts/update-renovate-ignores.py
+```
+
+Once the change is on the default branch, Renovate stops proposing any updates for those images.
+
+## Re-enabling updates
+
+Delete the `# renovate: ignore` comment from the manifest and commit. The hook removes the image from the managed rule and Renovate resumes upgrading it as usual.
+
+## Notes
+
+* The script scans `manifests/`, `argocd/`, `argocd-appsets/` and `helm/` (skipping `archive/`).
+* For `values.yaml` files with a separate `registry:` key, both `repository` and `registry/repository` forms are added to the rule, so it matches regardless of how Renovate names the dependency.
+* The managed rule is placed last in `packageRules` so it takes precedence over the automerge rules, and it is entirely owned by the script — don't edit it manually, and don't add your own rules with the same description.
+* `enabled: false` disables *all* update types (major/minor/patch/digest) for the image everywhere in the repo.

--- a/renovate.json
+++ b/renovate.json
@@ -49,22 +49,26 @@
       "username": "kenlasko",
       "password": "{{ secrets.DOCKER_CREDS }}"
     }
-  ],  
+  ],
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["cluster"],
+      "fileMatch": [
+        "cluster"
+      ],
       "matchStrings": [
-        "imageName:\\s*kenlasko\/cloudnativepg-gis-vchord:(?<currentValue>\\S+)"
+        "imageName:\\s*kenlasko/cloudnativepg-gis-vchord:(?<currentValue>\\S+)"
       ],
       "datasourceTemplate": "docker",
       "packageNameTemplate": "kenlasko/cloudnativepg-gis-vchord"
     },
     {
       "customType": "regex",
-      "fileMatch": ["kustomization.yaml"],
+      "fileMatch": [
+        "kustomization.yaml"
+      ],
       "matchStrings": [
-        "cloudnative-pg\/plugin-barman-cloud\/releases\/download\/v(?<currentValue>.*?)\/manifest.yaml"
+        "cloudnative-pg/plugin-barman-cloud/releases/download/v(?<currentValue>.*?)/manifest.yaml"
       ],
       "datasourceTemplate": "github-releases",
       "packageNameTemplate": "cloudnative-pg/plugin-barman-cloud"
@@ -89,7 +93,7 @@
         "regex"
       ],
       "matchUpdateTypes": [
-        "minor", 
+        "minor",
         "patch",
         "digest"
       ],
@@ -149,8 +153,12 @@
       "ignoreTests": true
     },
     {
-      "matchManagers": ["kustomize"],
-      "matchPackageNames": ["baseline"],
+      "matchManagers": [
+        "kustomize"
+      ],
+      "matchPackageNames": [
+        "baseline"
+      ],
       "enabled": false
     }
   ]

--- a/scripts/update-renovate-ignores.py
+++ b/scripts/update-renovate-ignores.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Sync Renovate ignore annotations from Kubernetes manifests into renovate.json.
+
+Renovate cannot read comments in files parsed by its built-in managers
+(kubernetes, helm-values, kustomize), so this script provides that workflow:
+annotate the pinned version directly in the manifest and run this script
+(automatically via pre-commit) to regenerate a managed package rule in
+renovate.json that disables updates for those images.
+
+Supported annotations:
+
+  helm-values (baseline chart values.yaml):
+      image:
+        repository: 11notes/radarr
+        tag: 6.2.0            # renovate: ignore
+        registry: ghcr.io
+
+  kubernetes manifest:
+      image: ghcr.io/foo/bar:v1.2.3   # renovate: ignore
+
+  kustomize image override:
+      images:
+        - name: ghcr.io/foo/bar
+          newTag: v1.2.3      # renovate: ignore
+
+  explicit dependency name (works anywhere in any YAML file):
+      # renovate: ignore=ghcr.io/foo/bar
+
+The generated rule is appended to packageRules with a fixed description and is
+fully owned by this script: do not edit it by hand. Removing the annotation
+from the manifest and re-running the script removes the dependency from the
+rule again.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RENOVATE_JSON = REPO_ROOT / "renovate.json"
+SCAN_DIRS = ["manifests", "argocd", "argocd-appsets", "helm"]
+SKIP_DIRS = {"archive"}
+
+MARKER_RE = re.compile(r"#\s*renovate:\s*ignore(?:=(?P<dep>\S+))?\s*$", re.IGNORECASE)
+RULE_DESCRIPTION = (
+    "Managed by scripts/update-renovate-ignores.py - do not edit. "
+    "Add or remove '# renovate: ignore' annotations in manifests instead."
+)
+
+
+def strip_value(raw):
+    """Return a YAML scalar value without quotes or trailing comment."""
+    value = raw.split("#", 1)[0].strip()
+    return value.strip("'\"")
+
+
+def indent_of(line):
+    stripped = line.lstrip(" ")
+    return len(line) - len(stripped)
+
+
+def image_ref_to_dep(ref):
+    """Strip the tag/digest from an image reference, keeping the registry."""
+    ref = ref.split("@", 1)[0]
+    head, sep, tail = ref.rpartition(":")
+    if sep and "/" not in tail:
+        ref = head
+    return ref
+
+
+def sibling_values(lines, index, keys):
+    """Collect values of sibling keys in the same YAML block as lines[index].
+
+    Walks up and down from the annotated line while indentation stays at the
+    same level (allowing for a '- ' list-item marker on the first line of a
+    block), stopping when the block ends.
+    """
+    base_indent = indent_of(lines[index])
+    found = {}
+
+    def inspect(line, first_of_item=False):
+        content = line.lstrip(" ")
+        if first_of_item and content.startswith("- "):
+            content = content[2:]
+        for key in keys:
+            match = re.match(rf"{key}\s*:\s*(.+)$", content)
+            if match:
+                found.setdefault(key, strip_value(match.group(1)))
+
+    # Walk upward until the block's indentation decreases.
+    for i in range(index - 1, -1, -1):
+        line = lines[i]
+        if not line.strip():
+            break
+        indent = indent_of(line)
+        list_item = line.lstrip(" ").startswith("- ") and indent == base_indent - 2
+        if indent < base_indent and not list_item:
+            break
+        if indent == base_indent or list_item:
+            inspect(line, first_of_item=list_item)
+        if list_item:
+            break
+    # Walk downward.
+    for i in range(index + 1, len(lines)):
+        line = lines[i]
+        if not line.strip():
+            break
+        indent = indent_of(line)
+        if indent < base_indent or line.lstrip(" ").startswith("- "):
+            break
+        if indent == base_indent:
+            inspect(line)
+    return found
+
+
+def deps_from_line(lines, index, path):
+    """Determine the Renovate dependency name(s) for an annotated line."""
+    line = lines[index]
+    marker = MARKER_RE.search(line)
+    if marker.group("dep"):
+        return {marker.group("dep")}
+
+    code = line[: marker.start()].strip()
+
+    match = re.match(r"(?:-\s+)?image\s*:\s*(\S+)", code)
+    if match:
+        return {image_ref_to_dep(strip_value(match.group(1)))}
+
+    match = re.match(r"newTag\s*:", code)
+    if match:
+        siblings = sibling_values(lines, index, ["newName", "name"])
+        name = siblings.get("newName") or siblings.get("name")
+        if name:
+            return {image_ref_to_dep(name)}
+
+    match = re.match(r"(?:tag|version)\s*:", code)
+    if match:
+        siblings = sibling_values(lines, index, ["repository", "registry"])
+        repository = siblings.get("repository")
+        if repository:
+            deps = {repository}
+            registry = siblings.get("registry")
+            if registry and not repository.startswith(registry):
+                deps.add(f"{registry}/{repository}")
+            return deps
+
+    print(
+        f"WARNING: {path}:{index + 1}: could not determine the image for this "
+        "'# renovate: ignore' annotation. Use the explicit form "
+        "'# renovate: ignore=<image>' instead.",
+        file=sys.stderr,
+    )
+    return set()
+
+
+def collect_ignored_deps():
+    deps = set()
+    problems = False
+    for scan_dir in SCAN_DIRS:
+        base = REPO_ROOT / scan_dir
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("*.y*ml")):
+            if SKIP_DIRS.intersection(part.lower() for part in path.parts):
+                continue
+            lines = path.read_text(encoding="utf-8").splitlines()
+            for index, line in enumerate(lines):
+                if not MARKER_RE.search(line):
+                    continue
+                found = deps_from_line(lines, index, path.relative_to(REPO_ROOT))
+                if found:
+                    print(f"  {path.relative_to(REPO_ROOT)}:{index + 1} -> {', '.join(sorted(found))}")
+                    deps.update(found)
+                else:
+                    problems = True
+    return deps, problems
+
+
+def sync_renovate_config(deps):
+    """Replace the managed rule in renovate.json. Returns True if it changed."""
+    config = json.loads(RENOVATE_JSON.read_text(encoding="utf-8"))
+    rules = config.setdefault("packageRules", [])
+    managed = [rule for rule in rules if rule.get("description") == RULE_DESCRIPTION]
+    others = [rule for rule in rules if rule.get("description") != RULE_DESCRIPTION]
+
+    new_rule = None
+    if deps:
+        new_rule = {
+            "description": RULE_DESCRIPTION,
+            "matchPackageNames": sorted(deps),
+            "enabled": False,
+        }
+
+    if managed == ([new_rule] if new_rule else []):
+        return False
+
+    # The managed rule goes last so it takes precedence over earlier rules.
+    config["packageRules"] = others + ([new_rule] if new_rule else [])
+    if not config["packageRules"]:
+        del config["packageRules"]
+    RENOVATE_JSON.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    return True
+
+
+def main():
+    print("Scanning for '# renovate: ignore' annotations...")
+    deps, problems = collect_ignored_deps()
+    if not deps:
+        print("  none found")
+    changed = sync_renovate_config(deps)
+    if changed:
+        print(f"renovate.json updated ({len(deps)} ignored package(s)).")
+    else:
+        print("renovate.json already up to date.")
+    # pre-commit fails the hook on its own when renovate.json is modified,
+    # so a change does not need a non-zero exit here.
+    if problems:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
This PR introduces a workflow for managing Renovate package ignores directly in Kubernetes manifests and Helm values files, rather than hand-editing `renovate.json`. A new Python script automatically syncs `# renovate: ignore` annotations from manifests into a managed package rule in `renovate.json`.

## Key Changes

- **New script**: `scripts/update-renovate-ignores.py` - Scans manifest files for `# renovate: ignore` annotations and generates a managed `packageRules` entry in `renovate.json`
  - Supports multiple annotation formats: helm-values, kubernetes manifests, kustomize overrides, and explicit dependency names
  - Intelligently extracts image references from YAML context (e.g., combining `repository` + `registry` keys)
  - Handles edge cases like list items and nested YAML structures
  - Fully owns the generated rule via a fixed description marker to prevent manual edits

- **New documentation**: `docs/RENOVATE-IGNORE.md` - User guide explaining how to use the annotation workflow, including examples for each supported format and notes on behavior

- **Pre-commit integration**: Added hook in `.pre-commit-config.yaml` to automatically run the sync script on commits touching YAML/JSON files

- **Code cleanup**: Fixed formatting inconsistencies in `renovate.json` (trailing whitespace, JSON array formatting)

## Implementation Details

The script uses regex-based YAML parsing to:
- Detect `# renovate: ignore` markers (with optional explicit dependency form)
- Walk YAML sibling keys to infer image names from context (e.g., `repository`, `registry`, `newName`)
- Strip image tags/digests to produce valid Renovate package names
- Maintain the managed rule at the end of `packageRules` for precedence over automerge rules

The generated rule disables all update types for matched packages, and removing annotations automatically removes them from the rule on the next run.

https://claude.ai/code/session_01MrkTmNy8fFkn5iEEbY9Fd2