### PR TITLE
Add GitHub Action to sync Renovate ignore annotations; re-pin Sonarr to v4.0.17

### DIFF
--- a/.github/workflows/renovate-ignore-sync.yaml
+++ b/.github/workflows/renovate-ignore-sync.yaml
@@ -1,0 +1,45 @@
+name: Sync Renovate ignore annotations
+
+# Keeps the managed rule in renovate.json in sync with '# renovate: ignore'
+# annotations in manifests, so the sync works no matter where a commit comes
+# from (VSCode, GitHub web UI, etc.). The pre-commit hook does the same thing
+# locally, but this is the safety net.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'manifests/**'
+      - 'argocd/**'
+      - 'argocd-appsets/**'
+      - 'helm/**'
+      - 'scripts/update-renovate-ignores.py'
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync annotations into renovate.json
+        run: python3 scripts/update-renovate-ignores.py
+
+      - name: Commit and push if renovate.json changed
+        run: |
+          if git diff --quiet renovate.json; then
+            echo "renovate.json already in sync"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add renovate.json
+          git commit -m "Sync Renovate ignore annotations into renovate.json"
+          # Retry in case something else (e.g. Renovate) pushed to main meanwhile
+          for i in 1 2 3; do
+            git push && exit 0
+            git pull --rebase
+          done
+          git push

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     hooks:
       - id: renovate-ignore-sync
         name: Sync '# renovate: ignore' annotations into renovate.json
-        entry: python3 scripts/update-renovate-ignores.py
-        language: system
+        entry: python scripts/update-renovate-ignores.py
+        language: python
         files: \.(ya?ml|json)$
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Renovate is set to automatically and silently upgrade every software package EXC
 
 When upgrades for the above packages are found, Renovate will create a pull request that has to be manually approved (or denied). Once approved, ArgoCD manages the actual upgrade as with any other software.
 
-If an automatic update breaks an app, the image can be pinned to a known-good version and excluded from further upgrades by adding a `# renovate: ignore` comment to the version line in the manifest. A pre-commit hook syncs these annotations into [renovate.json](/renovate.json). See [this document](/docs/RENOVATE-IGNORE.md) for details.
+If an automatic update breaks an app, the image can be pinned to a known-good version and excluded from further upgrades by adding a `# renovate: ignore` comment to the version line in the manifest. A [GitHub Action](/.github/workflows/renovate-ignore-sync.yaml) (and optionally a pre-commit hook) syncs these annotations into [renovate.json](/renovate.json). See [this document](/docs/RENOVATE-IGNORE.md) for details.
 
 ## Backups
 Since the repo is built using GitOps principles and config is stored in Github, backups aren't required for the bulk of the deployments. This does not cover persistent volumes. For persistent volumes running on NFS, I use [VolSync](/manifests/system/volsync) to backup PVCs to S3 storage. [Longhorn](/manifests/system/longhorn) PVCs uses its own internal backup mechanism to backup to the NAS, which is then in turn backed up to alternate storage.

--- a/docs/RENOVATE-IGNORE.md
+++ b/docs/RENOVATE-IGNORE.md
@@ -31,7 +31,7 @@ images:
 # renovate: ignore=ghcr.io/foo/bar
 ```
 
-Then commit. The [pre-commit](/docs/COMMIT-PRECHECK.md) hook runs [scripts/update-renovate-ignores.py](/scripts/update-renovate-ignores.py), which regenerates a managed rule at the end of `packageRules` in [renovate.json](/renovate.json):
+Then commit and push to `main`. The [renovate-ignore-sync GitHub Action](/.github/workflows/renovate-ignore-sync.yaml) runs [scripts/update-renovate-ignores.py](/scripts/update-renovate-ignores.py) on every push to `main` that touches manifests, and auto-commits the result. The script regenerates a managed rule at the end of `packageRules` in [renovate.json](/renovate.json):
 
 ```json
 {
@@ -44,13 +44,13 @@ Then commit. The [pre-commit](/docs/COMMIT-PRECHECK.md) hook runs [scripts/updat
 }
 ```
 
-If the hook modified `renovate.json`, pre-commit stops the commit; re-stage the file (`git add renovate.json`) and commit again. The script can also be run manually at any time:
+Once that sync commit lands on `main`, Renovate stops proposing any updates for those images.
+
+The same sync also runs locally as a [pre-commit](/docs/COMMIT-PRECHECK.md) hook (requires `pre-commit install` in the clone), which keeps `renovate.json` in the same commit as the annotation and closes the small window where Renovate could re-upgrade the image before the Action's sync commit lands. If the hook modifies `renovate.json`, pre-commit stops the commit; re-stage the file (`git add renovate.json`) and commit again. The script can also be run manually at any time:
 
 ```sh
 python3 scripts/update-renovate-ignores.py
 ```
-
-Once the change is on the default branch, Renovate stops proposing any updates for those images.
 
 ## Re-enabling updates
 

--- a/manifests/media/sonarr/base/values.yaml
+++ b/manifests/media/sonarr/base/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: 11notes/sonarr
-  tag: 4.0.19 # renovate: ignore
+  tag: 4.0.17 # renovate: ignore
   registry: ghcr.io
 extraLabels:
   appGroup: media-arr

--- a/renovate.json
+++ b/renovate.json
@@ -160,6 +160,14 @@
         "baseline"
       ],
       "enabled": false
+    },
+    {
+      "description": "Managed by scripts/update-renovate-ignores.py - do not edit. Add or remove '# renovate: ignore' annotations in manifests instead.",
+      "matchPackageNames": [
+        "11notes/sonarr",
+        "ghcr.io/11notes/sonarr"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

Follow-up to #212. The `# renovate: ignore` annotation added in `6c7a2a0` never made it into `renovate.json` because the sync relied on the pre-commit hook running locally, so Renovate re-upgraded Sonarr to v4.0.19 minutes after it was pinned. This makes the annotation workflow independent of any local setup:

- **New GitHub Action** (`.github/workflows/renovate-ignore-sync.yaml`): on every push to `main` touching `manifests/`, `argocd/`, `argocd-appsets/`, or `helm/`, runs `scripts/update-renovate-ignores.py` and auto-commits the `renovate.json` update. "Edit in VSCode, push to main" now just works, as do GitHub web UI edits.
- **Re-pins Sonarr to v4.0.17** with the managed rule (`11notes/sonarr`, `ghcr.io/11notes/sonarr`) already synced into `renovate.json`, so the ignore is active the moment this merges.
- **Pre-commit hook switched to `language: python`** so it works on Windows (no `python3`-on-PATH assumption). The hook is now an optional extra that closes the short race window between a push and the Action's sync commit — `pre-commit install` once per clone enables it.
- Docs updated to describe the Action as the primary sync mechanism.

## Test plan

- Sync script re-run against the re-pinned Sonarr values file; verified both dependency name forms land in the managed rule and that removing the annotation removes the rule
- `renovate.json` validated as JSON after sync
- Action's commit step is guarded (`git diff --quiet`) and its paths filter excludes `renovate.json`, so the sync commit cannot retrigger the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MrkTmNy8fFkn5iEEbY9Fd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrkTmNy8fFkn5iEEbY9Fd2)_